### PR TITLE
Added send_modes field on incoming (e)mails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 0.24.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Added send_modes field on incoming (e)mails.
+  [chris-adam]
 
 0.24.0 (2026-04-21)
 -------------------

--- a/src/imio/zamqp/dms/consumer.py
+++ b/src/imio/zamqp/dms/consumer.py
@@ -103,6 +103,7 @@ class IncomingMail(DMSMainFile, CommonMethods):
         mail_types_rec = api.portal.get_registry_record("imio.dms.mail.browser.settings.IImioDmsMailConfig.mail_types")
         mail_types = [dic["value"] for dic in mail_types_rec if dic["active"]]
         self.metadata["mail_type"] = mail_types[0]
+        self.metadata["send_modes"] = [u"post"]
         file_metadata = {
             "content_category": calculate_category_id(self.site["annexes_types"]["incoming_dms_files"]
                                                       ["incoming-dms-file"])
@@ -505,6 +506,7 @@ class IncomingEmail(DMSMainFile, CommonMethods):
             self.metadata["mail_type"] = u"email"
         else:
             self.metadata["mail_type"] = mail_types[0]
+        self.metadata["send_modes"] = [u"email"]
 
         intids = getUtility(IIntIds)
         with api.env.adopt_user(user=api.user.get_current()):


### PR DESCRIPTION
Depends on https://github.com/IMIO/imio.dms.mail/pull/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `send_modes` field to incoming mails and emails to indicate the delivery method (postal mail or email).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->